### PR TITLE
Docker compose con PostgreSQL 12.7 y gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Ignorar carpeta de datos de Postgres
+data/
+
+# Ignorar entornos virtuales
+venv/
+
+# Archivos de Python compilados
+*.pyc
+__pycache__/
+
+# Configuración local de VS Code
+.vscode/
+
+# Archivos temporales de sistema
+.DS_Store
+Thumbs.db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:12.7
+    container_name: postgres_presupuesto
+    restart: always
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: presupuesto2025
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./data:/var/lib/postgresql/data


### PR DESCRIPTION
Se agrega archivo docker-compose.yml que levanta un contenedor con PostgreSQL versión 12.7, exponiendo el puerto 5432 y con credenciales iniciales configuradas.
Se agrega archivo gitignore inicial